### PR TITLE
Update navbar links to use Django URLs

### DIFF
--- a/revlabs/templates/simulator/car_selection.html
+++ b/revlabs/templates/simulator/car_selection.html
@@ -10,9 +10,8 @@
 <body class="selection-body">
     <nav class="navbar">
         <div class="nav-links">
-            <a href="#">Home</a>
-            <a href="#">Circuits</a>
-            <a href="#" class="active" style="font-size: 1.3rem;">Vehicles</a>
+            <a href="{% url 'track_selection' %}">Circuits</a>
+            <a href="{% url 'car_selection' %}?track={{ selected_track.id }}" class="active" style="font-size: 1.3rem;">Vehicles</a>
         </div>
         <div class="user-profile">
             <span>DanDdC</span>

--- a/revlabs/templates/simulator/dashboard.html
+++ b/revlabs/templates/simulator/dashboard.html
@@ -10,9 +10,8 @@
 <body>
     <nav class="navbar">
         <div class="nav-links">
-            <a href="#">Home</a>
-            <a href="#">Circuits</a>
-            <a href="{% url 'car_selection' %}" class="active">Vehicles</a>
+            <a href="{% url 'track_selection' %}">Circuits</a>
+            <a href="{% url 'car_selection' %}?track={{ track.id }}" class="active">Vehicles</a>
         </div>
         <div class="user-profile">
             <span>DanDdC</span>

--- a/revlabs/templates/simulator/track_selection.html
+++ b/revlabs/templates/simulator/track_selection.html
@@ -10,9 +10,7 @@
 <body class="selection-body">
     <nav class="navbar">
         <div class="nav-links">
-            <a href="#">Home</a>
-            <a href="#">Circuits</a>
-            <a href="#" class="active" style="font-size: 1.3rem;">Vehicles</a>
+            <a href="#" class="active" style="font-size: 1.3rem;">Circuits</a>
         </div>
         <div class="user-profile">
             <span>DanDdC</span>


### PR DESCRIPTION
Replace placeholder '#' nav links with Django URL tags across simulator templates. Circuits links now point to the track_selection view and Vehicles links point to car_selection with the currently selected track passed as a query parameter (using selected_track.id or track.id). Adjust active states for each page (Circuits active on track selection, Vehicles active on car/ dashboard) and remove unused Home links in the selection templates to enable proper navigation and preserve the selected track.